### PR TITLE
Guard Watcom pragmas for GCC compatibility

### DIFF
--- a/ANIM.CPP
+++ b/ANIM.CPP
@@ -231,7 +231,9 @@ bool AnimClass::Render(bool forced)
  *   09/24/1994 JLB : Created.                                                                 *
  *   05/19/1995 JLB : Added white translucent effect.                                          *
  *=============================================================================================*/
+#ifdef __WATCOMC__
 #pragma off (unreferenced)
+#endif
 void AnimClass::Draw_It(int x, int y, WindowNumberType window)
 {
 	Validate();

--- a/IPXCONN.CPP
+++ b/IPXCONN.CPP
@@ -530,9 +530,11 @@ void IPXConnClass::Close_Socket(unsigned short socket)
  * HISTORY:                                                                *
  *   12/16/1994 BR : Created.                                              *
  *=========================================================================*/
+#ifdef __WATCOMC__
 #pragma off (unreferenced)
+#endif
 int IPXConnClass::Send_To(char *buf, int buflen, IPXAddressClass *address,
-	NetNodeType immed)
+        NetNodeType immed)
 {
 
 	void *hdr_ptr;
@@ -623,7 +625,9 @@ CCDebugString (tempbuf);
 
 
 }
+#ifdef __WATCOMC__
 #pragma on (unreferenced)
+#endif
 
 /***************************************************************************
  * IPXConnClass::Broadcast -- broadcasts the given packet						*

--- a/NULLMGR.CPP
+++ b/NULLMGR.CPP
@@ -199,7 +199,9 @@ NullModemClass::~NullModemClass ()
  *   12/20/1994 BR : Created.                                              *
  *=========================================================================*/
 //int NullModemClass::Init (int port, int irq, int baud, char parity, int wordlen, int stopbits)
+#ifdef __WATCOMC__
 #pragma off (unreferenced)
+#endif
 int NullModemClass::Init (int port, int ,char *dev_name, int baud, char parity, int wordlen, int stopbits, int flowcontrol)
 {
 	int com;

--- a/RADAR.CPP
+++ b/RADAR.CPP
@@ -1111,7 +1111,9 @@ void RadarClass::Cell_XY_To_Radar_Pixel(int cellx, int celly, int &x, int &y)
  *   05/22/1991 JLB : Created.                                                                 *
  *   11/17/1995 PWG : Created.                                                                 *
  *=============================================================================================*/
+#ifdef __WATCOMC__
 #pragma argsused
+#endif
 void RadarClass::Radar_Cursor(int forced)
 {
 	static 					_last_pos = -1;

--- a/WATCOM.H
+++ b/WATCOM.H
@@ -38,6 +38,7 @@
 #ifndef WATCOM_H
 #define WATCOM_H
 
+#ifdef __WATCOMC__
 // Turn all warnings into errors.
 #pragma warning * 0
 
@@ -73,5 +74,6 @@
 
 // Turns off "expression with side effect in sizeof()". This is needed if memchecker is used.
 #pragma warning 472 9
+#endif // __WATCOMC__
 
 #endif

--- a/WINSTUB.CPP
+++ b/WINSTUB.CPP
@@ -499,7 +499,9 @@ int	DebugColour=1;
 
 
 extern "C" void Set_Palette_Register(int number,int red ,int green ,int blue);
+#ifdef __WATCOMC__
 #pragma off (unreferenced)
+#endif
 void Colour_Debug (int call_number)
 {
 	//#if 0
@@ -516,7 +518,9 @@ void Colour_Debug (int call_number)
 	//#endif
 }
 
+#ifdef __WATCOMC__
 #pragma on (unreferenced)
+#endif
 
 
 


### PR DESCRIPTION
## Summary
- Wrap Watcom-specific `#pragma` directives in `#ifdef __WATCOMC__` so GCC ignores them.
- Update several simple source files to conditionally compile Watcom pragmas.

## Testing
- `g++ -std=c++17 -c ANIM.CPP` *(fails: function.h includes windows.h missing)*
- `apt-get update` *(fails: repository access blocked)*


------
https://chatgpt.com/codex/tasks/task_e_689f47652c7c8321882249c96b15e6cb