### PR TITLE
Replace Watcom pragmas with GCC diagnostics

### DIFF
--- a/FUNCTION.H
+++ b/FUNCTION.H
@@ -42,74 +42,74 @@
 Map (screen) class heirarchy.
 
  MapeditClass (most derived class) -- scenario editor
-        ³
+        Â³
    MouseClass -- handles mouse animation and display control
-        ³
+        Â³
   ScrollClass -- map scroll handler
-        ³
+        Â³
     HelpClass -- pop-up help text handler
-        ³
+        Â³
      TabClass -- file folder tab screen mode control dispatcher
-        ³
+        Â³
  SidebarClass -- displays and controls construction list sidebar
-        ³
+        Â³
    PowerClass -- display power production/consumption bargraph
-        ³
+        Â³
    RadarClass -- displays and controls radar map
-        ³
+        Â³
  DisplayClass -- general tactical map display handler
-        ³
+        Â³
      MapClass -- general tactical map data handler
-        ³
+        Â³
  GScreenClass (pure virtual base class) -- generic screen control
 
                           AbstractClass
-                                  ³
-                                  ³
-                                  ³
-                                  ³
+                                  Â³
+                                  Â³
+                                  Â³
+                                  Â³
                             ObjectClass
-                                  ³
-       ÚÄÄÄÄÄÄÂÄÄÄÄÄÄÄÄÄÄÂÄÄÄÄÄÄÄÄÅÄÄÄÄÄÄÄÄÂÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÂÄÄÄÄÄÄÄÄÄÄÄ¿
-   AnimClass  ³  TemplateClass    ³        ÃÄ FuseClass     ³    TerrainClass
-              ³                   ³        ÃÄ FlyClass      ³
-              ³                   ³  BulletClass            ³
+                                  Â³
+       ÃšÃ„Ã„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã…Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Â¿
+   AnimClass  Â³  TemplateClass    Â³        ÃƒÃ„ FuseClass     Â³    TerrainClass
+              Â³                   Â³        ÃƒÃ„ FlyClass      Â³
+              Â³                   Â³  BulletClass            Â³
        OverlayClass        MissionClass               SmudgeClass
-                                  ³
+                                  Â³
                              RadioClass
-                                  ³
-                                  ÃÄ CrewClass
-                                  ÃÄ FlasherClass
-                                  ÃÄ StageClass
-                                  ÃÄ CargoClass
+                                  Â³
+                                  ÃƒÃ„ CrewClass
+                                  ÃƒÃ„ FlasherClass
+                                  ÃƒÃ„ StageClass
+                                  ÃƒÃ„ CargoClass
                             TechnoClass
-                                  ³
-         ÚÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÁÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ¿
+                                  Â³
+         ÃšÃ„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„ÃÃ„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Â¿
      FootClass                                         BuildingClass
-         ³
-         ÃÄÄÄÄÄÄÄÄÄÄÄÄÄÄÂÄÄÄÄÄÄÄÄÄÄÄÄÄ¿
-    DriveClass  InfantryClass         ÃÄ FlyClass
-         ³                      AircraftClass
+         Â³
+         ÃƒÃ„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Â¿
+    DriveClass  InfantryClass         ÃƒÃ„ FlyClass
+         Â³                      AircraftClass
    TurretClass
-         ³
+         Â³
    TarComClass
-         ³
+         Â³
      UnitClass
 
 
                             AbstractTypeClass
-                                    ³
+                                    Â³
                               ObjectTypeClass
-                                    ³
-             ÚÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÅÄÄÄÄÄÄÄÄÄÄÄÄÂÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ¿
-             ³                      ³            ³                 ³
-       TechnoTypeClass              ³            ³                 ³
-             ³                BulletTypeClass    ³                 ³
-             ³                           TemplateTypeClass         ³
-    ÚÄÄÄÄÄÄÄÄÁÄÄÄÄÄÂÄÄÄÄÄÄÄÄÄÄÄÂÄÄÄÄÄÄÄÄÄÄÄÄÄÄ¿             TerrainTypeClass
-    ³              ³           ³              ³
-UnitTypeClass      ³   BuildingTypeClass      ³
-                   ³                  InfantryTypeClass
+                                    Â³
+             ÃšÃ„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã…Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Â¿
+             Â³                      Â³            Â³                 Â³
+       TechnoTypeClass              Â³            Â³                 Â³
+             Â³                BulletTypeClass    Â³                 Â³
+             Â³                           TemplateTypeClass         Â³
+    ÃšÃ„Ã„Ã„Ã„Ã„Ã„Ã„Ã„ÃÃ„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Â¿             TerrainTypeClass
+    Â³              Â³           Â³              Â³
+UnitTypeClass      Â³   BuildingTypeClass      Â³
+                   Â³                  InfantryTypeClass
            AircraftTypeClass
 #endif
 
@@ -136,7 +136,9 @@ typedef int bool;
 */
 #define NOMEMCHECK
 
-#include	"watcom.h"
+#if defined(__WATCOMC__) || defined(__GNUC__)
+#include        "watcom.h"
+#endif
 #define FILE_H
 #define WWMEM_H
 #include "compat.h"

--- a/REAL.H
+++ b/REAL.H
@@ -42,74 +42,76 @@
 Map (screen) class heirarchy.
 
  MapeditClass (most derived class) -- scenario editor
-        ³
+        Â³
    MouseClass -- handles mouse animation and display control
-        ³
+        Â³
   ScrollClass -- map scroll handler
-        ³
+        Â³
     HelpClass -- pop-up help text handler
-        ³
+        Â³
      TabClass -- file folder tab screen mode control dispatcher
-        ³
+        Â³
  SidebarClass -- displays and controls construction list sidebar
-        ³
+        Â³
    PowerClass -- display power production/consumption bargraph
-        ³
+        Â³
    RadarClass -- displays and controls radar map
-        ³
+        Â³
  DisplayClass -- general tactical map display handler
-        ³
+        Â³
      MapClass -- general tactical map data handler
-        ³
+        Â³
  GScreenClass (pure virtual base class) -- generic screen control
 
                           AbstractClass
-                                  ³
-                                  ³
-                                  ³
-                                  ³
+                                  Â³
+                                  Â³
+                                  Â³
+                                  Â³
                             ObjectClass
-                                  ³
-       ÚÄÄÄÄÄÄÂÄÄÄÄÄÄÄÄÄÄÂÄÄÄÄÄÄÄÄÅÄÄÄÄÄÄÄÄÂÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÂÄÄÄÄÄÄÄÄÄÄÄ¿
-   AnimClass  ³  TemplateClass    ³        ÃÄ FuseClass     ³    TerrainClass
-              ³                   ³        ÃÄ FlyClass      ³
-              ³                   ³  BulletClass            ³
+                                  Â³
+       ÃšÃ„Ã„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã…Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Â¿
+   AnimClass  Â³  TemplateClass    Â³        ÃƒÃ„ FuseClass     Â³    TerrainClass
+              Â³                   Â³        ÃƒÃ„ FlyClass      Â³
+              Â³                   Â³  BulletClass            Â³
        OverlayClass        MissionClass               SmudgeClass
-                                  ³
+                                  Â³
                              RadioClass
-                                  ³
-                                  ÃÄ CrewClass
-                                  ÃÄ FlasherClass
-                                  ÃÄ StageClass
-                                  ÃÄ CargoClass
+                                  Â³
+                                  ÃƒÃ„ CrewClass
+                                  ÃƒÃ„ FlasherClass
+                                  ÃƒÃ„ StageClass
+                                  ÃƒÃ„ CargoClass
                             TechnoClass
-                                  ³
-         ÚÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÁÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ¿
+                                  Â³
+         ÃšÃ„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„ÃÃ„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Â¿
      FootClass                                         BuildingClass
-         ³
-         ÃÄÄÄÄÄÄÄÄÄÄÄÄÄÄÂÄÄÄÄÄÄÄÄÄÄÄÄÄ¿
-    DriveClass  InfantryClass         ÃÄ FlyClass
-         ³                      AircraftClass
+         Â³
+         ÃƒÃ„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Â¿
+    DriveClass  InfantryClass         ÃƒÃ„ FlyClass
+         Â³                      AircraftClass
    TurretClass
-         ³
+         Â³
    TarComClass
-         ³
+         Â³
      UnitClass
 
 
                             AbstractTypeClass
-                                    ³
+                                    Â³
                               ObjectTypeClass
-                                    ³
-             ÚÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÅÄÄÄÄÄÄÄÄÄÄÄÄÂÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ¿
-             ³                      ³            ³                 ³
-       TechnoTypeClass              ³            ³                 ³
-             ³                BulletTypeClass    ³                 ³
-             ³                           TemplateTypeClass         ³
-    ÚÄÄÄÄÄÄÄÄÁÄÄÄÄÄÂÄÄÄÄÄÄÄÄÄÄÄÂÄÄÄÄÄÄÄÄÄÄÄÄÄÄ¿             TerrainTypeClass
-    ³              ³           ³              ³
-UnitTypeClass      ³   BuildingTypeClass      ³
-                   ³                  InfantryTypeClass
+                                    Â³
+             ÃšÃ„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã…Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Â¿
+             Â³                      Â³            Â³                 Â³
+       TechnoTypeClass              Â³            Â³                 Â³
+             Â³                BulletTypeClass    Â³                 Â³
+             Â³                           TemplateTypeClass         Â³
+    ÃšÃ„Ã„Ã„Ã„Ã„Ã„Ã„Ã„ÃÃ„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã‚Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Ã„Â¿             TerrainTypeClass
+    Â³              Â³           Â³              Â³
+UnitTypeClass      Â³   BuildingTypeClass      Â³
+#if defined(__WATCOMC__) || defined(__GNUC__)
+#include        "watcom.h"
+#endif
            AircraftTypeClass
 #endif
 

--- a/WATCOM.H
+++ b/WATCOM.H
@@ -1,42 +1,44 @@
 /*
-**	Command & Conquer(tm)
-**	Copyright 2025 Electronic Arts Inc.
+**      Command & Conquer(tm)
+**      Copyright 2025 Electronic Arts Inc.
 **
-**	This program is free software: you can redistribute it and/or modify
-**	it under the terms of the GNU General Public License as published by
-**	the Free Software Foundation, either version 3 of the License, or
-**	(at your option) any later version.
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
 **
-**	This program is distributed in the hope that it will be useful,
-**	but WITHOUT ANY WARRANTY; without even the implied warranty of
-**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-**	GNU General Public License for more details.
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
 **
-**	You should have received a copy of the GNU General Public License
-**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/* $Header:   F:\projects\c&c\vcs\code\watcom.h_v   2.13   16 Oct 1995 16:45:58   JOE_BOSTIC  $ */
-/*********************************************************************************************** 
- ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               *** 
- *********************************************************************************************** 
- *                                                                                             * 
- *                 Project Name : Command & Conquer                                            * 
- *                                                                                             * 
- *                    File Name : WATCOM.H                                                     * 
- *                                                                                             * 
- *                   Programmer : Joe L. Bostic                                                * 
- *                                                                                             * 
- *                   Start Date : 03/12/95                                                     * 
- *                                                                                             * 
- *                  Last Update : March 12, 1995 [JLB]                                         * 
- *                                                                                             * 
- *---------------------------------------------------------------------------------------------* 
- * Functions:                                                                                  * 
+/* $Header:   F:\\projects\\c&c\\vcs\\code\\watcom.h_v   2.13   16 Oct 1995 16:45:58   JOE_BOSTIC  $ */
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : Command & Conquer                                            *
+ *                                                                                             *
+ *                    File Name : WATCOM.H                                                     *
+ *                                                                                             *
+ *                   Programmer : Joe L. Bostic                                                *
+ *                                                                                             *
+ *                   Start Date : 03/12/95                                                     *
+ *                                                                                             *
+ *                  Last Update : March 12, 1995 [JLB]                                         *
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * Functions:                                                                                  *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #ifndef WATCOM_H
 #define WATCOM_H
+
+#if defined(__WATCOMC__)
 
 // Turn all warnings into errors.
 #pragma warning * 0
@@ -73,5 +75,13 @@
 
 // Turns off "expression with side effect in sizeof()". This is needed if memchecker is used.
 #pragma warning 472 9
+
+#elif defined(__GNUC__)
+
+// GCC: treat all warnings as errors and silence unused parameter warnings.
+#pragma GCC diagnostic error "-Wall"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+#endif
 
 #endif


### PR DESCRIPTION
## Summary
- Wrap legacy Watcom warning pragmas in `WATCOM.H` with a GCC fallback using `#pragma GCC diagnostic` to treat warnings as errors and suppress unused parameters.
- Only include `watcom.h` in translation units when compiling with Watcom or GCC to avoid unnecessary includes on other toolchains.

## Testing
- `make -f MAKEFILE` *(fails: MAKEFILE:37: *** missing separator.  Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_689f49b87a048321a7dbad207d12e394